### PR TITLE
Initial check-in of the Shim layer.

### DIFF
--- a/src/main/java/io/opentracing/v_030/shim/ActiveSpanShim.java
+++ b/src/main/java/io/opentracing/v_030/shim/ActiveSpanShim.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import io.opentracing.Scope;
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.ActiveSpan;
+
+import java.util.Map;
+
+public class ActiveSpanShim implements ActiveSpan, SpanWrapper {
+    final Scope scope;
+    final SpanContext context;
+
+    public ActiveSpanShim(Scope scope) {
+        if (scope == null) {
+            throw new IllegalArgumentException("scope");
+        }
+
+        this.scope = scope;
+        this.context = new SpanContextShim(scope.span().context());
+    }
+
+    protected Scope scope() {
+        return scope;
+    }
+
+    @Override
+    public io.opentracing.Span span() {
+        return scope.span();
+    }
+
+    @Override
+    public void deactivate() {
+        scope.close();
+    }
+
+    @Override
+    public void close() {
+        deactivate();
+    }
+
+    @Override
+    public Continuation capture() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SpanContext context() {
+        return context;
+    }
+
+    @Override
+    public ActiveSpanShim setTag(String key, String value) {
+        scope.span().setTag(key, value);
+        return this;
+    }
+
+    @Override
+    public ActiveSpanShim setTag(String key, boolean value) {
+        scope.span().setTag(key, value);
+        return this;
+    }
+
+    @Override
+    public ActiveSpanShim setTag(String key, Number value) {
+        scope.span().setTag(key, value);
+        return this;
+    }
+
+    @Override
+    public final ActiveSpanShim log(Map<String, ?> fields) {
+        scope.span().log(fields);
+        return this;
+    }
+
+    @Override
+    public final ActiveSpanShim log(long timestampMicros, Map<String, ?> fields) {
+        scope.span().log(timestampMicros, fields);
+        return this;
+    }
+
+    @Override
+    public ActiveSpanShim log(String event) {
+        scope.span().log(event);
+        return this;
+    }
+
+    @Override
+    public ActiveSpanShim log(long timestampMicroseconds, String event) {
+        scope.span().log(timestampMicroseconds, event);
+        return this;
+    }
+
+    @Override
+    public ActiveSpanShim setBaggageItem(String key, String value) {
+        scope.span().setBaggageItem(key, value);
+        return this;
+    }
+
+    @Override
+    public String getBaggageItem(String key) {
+        return scope.span().getBaggageItem(key);
+    }
+
+    @Override
+    public ActiveSpanShim setOperationName(String operationName) {
+        scope.span().setOperationName(operationName);
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return scope.span().toString();
+    }
+}

--- a/src/main/java/io/opentracing/v_030/shim/ActiveSpanShim.java
+++ b/src/main/java/io/opentracing/v_030/shim/ActiveSpanShim.java
@@ -121,6 +121,14 @@ public class ActiveSpanShim implements ActiveSpan, SpanWrapper {
     }
 
     @Override
+    public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof ActiveSpanShim))
+            return false;
+
+        return scope.equals(((ActiveSpanShim)obj).scope());
+    }
+
+    @Override
     public String toString() {
         return scope.span().toString();
     }

--- a/src/main/java/io/opentracing/v_030/shim/AutoFinishTracerShim.java
+++ b/src/main/java/io/opentracing/v_030/shim/AutoFinishTracerShim.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import io.opentracing.Scope;
+import io.opentracing.ScopeManager;
+import io.opentracing.SpanContext;
+import io.opentracing.propagation.Format;
+import io.opentracing.v_030.util.AutoFinishScope;
+import io.opentracing.v_030.util.AutoFinishScopeManager;
+import io.opentracing.v_030.ActiveSpan;
+
+public class AutoFinishTracerShim extends TracerShim {
+    public AutoFinishTracerShim(io.opentracing.Tracer tracer) {
+        super(tracer);
+
+        if (!(tracer.scopeManager() instanceof AutoFinishScopeManager)) {
+            throw new IllegalArgumentException("tracer.scopeManager is not AutoFinishScopeManager");
+        }
+    }
+
+    @Override
+    protected ActiveSpanShim createActiveSpanShim(Scope scope) {
+        return new AutoFinishActiveSpanShim(scope);
+    }
+
+    final static class AutoFinishActiveSpanShim extends ActiveSpanShim {
+        public AutoFinishActiveSpanShim(Scope scope) {
+            super(scope);
+        }
+
+        @Override
+        public Continuation capture() {
+            return new Continuation(((AutoFinishScope)scope()).capture());
+        }
+
+        private final class Continuation implements ActiveSpan.Continuation {
+            AutoFinishScope.Continuation continuation;
+
+            Continuation(AutoFinishScope.Continuation continuation) {
+                this.continuation = continuation;
+            }
+
+            @Override
+            public ActiveSpanShim activate() {
+                return new AutoFinishActiveSpanShim(continuation.activate());
+            }
+        }
+    }
+}

--- a/src/main/java/io/opentracing/v_030/shim/FormatConverter.java
+++ b/src/main/java/io/opentracing/v_030/shim/FormatConverter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.v_030.propagation.Format;
+import io.opentracing.v_030.propagation.TextMap;
+
+final class FormatConverter {
+    private FormatConverter() {}
+
+    public static io.opentracing.propagation.Format toUpstreamFormat(Format format) {
+        if (format == null) {
+            return null; // Bail out early.
+        }
+
+        if (format == Format.Builtin.TEXT_MAP) {
+            return io.opentracing.propagation.Format.Builtin.TEXT_MAP;
+        }
+        if (format == Format.Builtin.HTTP_HEADERS) {
+            return io.opentracing.propagation.Format.Builtin.HTTP_HEADERS;
+        }
+        if (format == Format.Builtin.BINARY) {
+            return io.opentracing.propagation.Format.Builtin.BINARY;
+        }
+
+        throw new UnsupportedOperationException("Format not supported");
+    }
+
+    public static <C> Object toUpstreamCarrier(Format format, C carrier) {
+        if (format == Format.Builtin.TEXT_MAP || format == Format.Builtin.HTTP_HEADERS) {
+            return new TextMapUpstreamShim((TextMap)carrier);
+        }
+
+        return carrier;
+    }
+}

--- a/src/main/java/io/opentracing/v_030/shim/SpanContextShim.java
+++ b/src/main/java/io/opentracing/v_030/shim/SpanContextShim.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import io.opentracing.v_030.SpanContext;
+
+import java.util.Map;
+
+class SpanContextShim implements SpanContext {
+    final io.opentracing.SpanContext context;
+
+    public SpanContextShim(io.opentracing.SpanContext context) {
+        this.context = context;
+    }
+
+    public io.opentracing.SpanContext context() {
+        return context;
+    }
+
+    @Override
+    public Iterable<Map.Entry<String, String>> baggageItems() {
+        return context.baggageItems();
+    }
+}

--- a/src/main/java/io/opentracing/v_030/shim/SpanShim.java
+++ b/src/main/java/io/opentracing/v_030/shim/SpanShim.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Span;
+
+import java.util.Map;
+
+public class SpanShim implements Span, SpanWrapper {
+    final io.opentracing.Span span;
+    final SpanContext context;
+
+    public SpanShim(io.opentracing.Span span) {
+        this.span = span;
+        this.context = new SpanContextShim(span().context());
+    }
+
+    @Override
+    public io.opentracing.Span span() {
+        return span;
+    }
+
+    @Override
+    public void finish() {
+        span.finish();
+    }
+
+    @Override
+    public void finish(long finishMicros) {
+        span.finish(finishMicros);
+    }
+
+    @Override
+    public SpanContext context() {
+        return context;
+    }
+
+    @Override
+    public SpanShim setTag(String key, String value) {
+        span.setTag(key, value);
+        return this;
+    }
+
+    @Override
+    public SpanShim setTag(String key, boolean value) {
+        span.setTag(key, value);
+        return this;
+    }
+
+    @Override
+    public SpanShim setTag(String key, Number value) {
+        span.setTag(key, value);
+        return this;
+    }
+
+    @Override
+    public final SpanShim log(Map<String, ?> fields) {
+        span.log(fields);
+        return this;
+    }
+
+    @Override
+    public final SpanShim log(long timestampMicros, Map<String, ?> fields) {
+        span.log(timestampMicros, fields);
+        return this;
+    }
+
+    @Override
+    public SpanShim log(String event) {
+        span.log(event);
+        return this;
+    }
+
+    @Override
+    public SpanShim log(long timestampMicroseconds, String event) {
+        span.log(timestampMicroseconds, event);
+        return this;
+    }
+
+    @Override
+    public SpanShim setBaggageItem(String key, String value) {
+        span.setBaggageItem(key, value);
+        return this;
+    }
+
+    @Override
+    public String getBaggageItem(String key) {
+        return span.getBaggageItem(key);
+    }
+
+    @Override
+    public SpanShim setOperationName(String operationName) {
+        span.setOperationName(operationName);
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return span.toString();
+    }
+}

--- a/src/main/java/io/opentracing/v_030/shim/SpanShim.java
+++ b/src/main/java/io/opentracing/v_030/shim/SpanShim.java
@@ -107,6 +107,14 @@ public class SpanShim implements Span, SpanWrapper {
     }
 
     @Override
+    public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof SpanShim))
+            return false;
+
+        return span.equals(((SpanShim)obj).span);
+    }
+
+    @Override
     public String toString() {
         return span.toString();
     }

--- a/src/main/java/io/opentracing/v_030/shim/SpanWrapper.java
+++ b/src/main/java/io/opentracing/v_030/shim/SpanWrapper.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+public interface SpanWrapper {
+    io.opentracing.Span span();
+}

--- a/src/main/java/io/opentracing/v_030/shim/TextMapUpstreamShim.java
+++ b/src/main/java/io/opentracing/v_030/shim/TextMapUpstreamShim.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import io.opentracing.v_030.propagation.TextMap;
+
+import java.util.Iterator;
+import java.util.Map;
+
+class TextMapUpstreamShim implements io.opentracing.propagation.TextMap {
+    final TextMap textMap;
+
+    public TextMapUpstreamShim(TextMap textMap) {
+        this.textMap = textMap;
+    }
+
+    public TextMap textMap() {
+        return textMap;
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, String>> iterator() {
+        return textMap.iterator();
+    }
+
+    @Override
+    public void put(String key, String value) {
+        textMap.put(key, value);
+    }
+}

--- a/src/main/java/io/opentracing/v_030/shim/TracerShim.java
+++ b/src/main/java/io/opentracing/v_030/shim/TracerShim.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import io.opentracing.ScopeManager;
+import io.opentracing.Scope;
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.BaseSpan;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.v_030.propagation.Format;
+
+import java.util.Map;
+
+public class TracerShim implements Tracer {
+    final io.opentracing.Tracer tracer;
+
+    public TracerShim(io.opentracing.Tracer tracer) {
+        checkArgumentNotNull(tracer, "tracer");
+
+        this.tracer = tracer;
+    }
+
+    void checkArgumentNotNull(Object value, String argName) {
+        if (value == null) {
+            throw new IllegalArgumentException(argName + " cannot be null");
+        }
+    }
+
+    protected ActiveSpanShim createActiveSpanShim(Scope scope) {
+        return new ActiveSpanShim(scope);
+    }
+
+    protected SpanShim createSpanShim(io.opentracing.Span span) {
+        return new SpanShim(span);
+    }
+
+    @Override
+    public ActiveSpan activeSpan() {
+        if (tracer.scopeManager().active() == null) {
+            return null;
+        }
+
+        return createActiveSpanShim(tracer.scopeManager().active());
+    }
+
+    @Override
+    public ActiveSpan makeActive(Span span) {
+        checkArgumentNotNull(span, "span");
+
+        io.opentracing.Span wrappedSpan = ((SpanWrapper)span).span();
+        return createActiveSpanShim(tracer.scopeManager().activate(wrappedSpan));
+    }
+
+    @Override
+    public SpanBuilder buildSpan(String operationName) {
+        return new SpanBuilderShim(tracer.buildSpan(operationName));
+    }
+
+    @Override
+    public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {
+        checkArgumentNotNull(spanContext, "spanContext");
+
+        tracer.inject(((SpanContextShim)spanContext).context(),
+                FormatConverter.toUpstreamFormat(format),
+                FormatConverter.toUpstreamCarrier(format, carrier));
+    }
+
+    @Override
+    public <C> SpanContext extract(Format<C> format, C carrier) {
+        io.opentracing.SpanContext context = tracer.extract(FormatConverter.toUpstreamFormat(format),
+                FormatConverter.toUpstreamCarrier(format, carrier));
+        return new SpanContextShim(context);
+    }
+
+    private final class SpanBuilderShim implements Tracer.SpanBuilder {
+        io.opentracing.Tracer.SpanBuilder builder;
+
+        public SpanBuilderShim(io.opentracing.Tracer.SpanBuilder builder) {
+            this.builder = builder;
+        }
+
+        @Override
+        public SpanBuilderShim asChildOf(SpanContext parent) {
+            checkArgumentNotNull(parent, "parent");
+
+            builder.asChildOf(((SpanContextShim)parent).context());
+            return this;
+        }
+
+        @Override
+        public SpanBuilderShim asChildOf(BaseSpan<?> parent) {
+            checkArgumentNotNull(parent, "parent");
+
+            builder.asChildOf(((SpanWrapper)parent).span());
+            return this;
+        }
+
+        @Override
+        public SpanBuilderShim addReference(String referenceType, SpanContext referencedContext) {
+            checkArgumentNotNull(referencedContext, "referencedContext");
+
+            builder.addReference(referenceType, ((SpanContextShim)referencedContext).context());
+            return this;
+        }
+
+        @Override
+        public SpanBuilderShim ignoreActiveSpan() {
+            builder.ignoreActiveSpan();
+            return this;
+        }
+
+        @Override
+        public SpanBuilderShim withTag(String key, String value) {
+            builder.withTag(key, value);
+            return this;
+        }
+
+        @Override
+        public SpanBuilderShim withTag(String key, boolean value) {
+            builder.withTag(key, value);
+            return this;
+        }
+
+        @Override
+        public SpanBuilderShim withTag(String key, Number value) {
+            builder.withTag(key, value);
+            return this;
+        }
+
+        @Override
+        public SpanBuilderShim withStartTimestamp(long microseconds) {
+            builder.withStartTimestamp(microseconds);
+            return this;
+        }
+
+        @Override
+        public ActiveSpan startActive() {
+            Scope scope = builder.startActive();
+            return createActiveSpanShim(scope);
+        }
+
+        @Override
+        public Span startManual() {
+            return createSpanShim(builder.startManual());
+        }
+
+        @Override
+        public Span start() {
+            return createSpanShim(builder.start());
+        }
+    }
+}

--- a/src/main/java/io/opentracing/v_030/util/AutoFinishScope.java
+++ b/src/main/java/io/opentracing/v_030/util/AutoFinishScope.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.util;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class AutoFinishScope implements Scope {
+    final AutoFinishScopeManager manager;
+    final AtomicInteger refCount;
+    private final Span wrapped;
+    private final AutoFinishScope toRestore;
+
+    AutoFinishScope(AutoFinishScopeManager manager, AtomicInteger refCount, Span wrapped) {
+        this.manager = manager;
+        this.refCount = refCount;
+        this.wrapped = wrapped;
+        this.toRestore = manager.tlsScope.get();
+        manager.tlsScope.set(this);
+    }
+
+    public class Continuation {
+        public Continuation() {
+            refCount.incrementAndGet();
+        }
+
+        public AutoFinishScope activate() {
+            return new AutoFinishScope(manager, refCount, wrapped);
+        }
+    }
+
+    public Continuation capture() {
+        return new Continuation();
+    }
+
+    @Override
+    public void close() {
+        if (manager.tlsScope.get() != this) {
+            return;
+        }
+
+        if (refCount.decrementAndGet() == 0) {
+            wrapped.finish();
+        }
+
+        manager.tlsScope.set(toRestore);
+    }
+
+    @Override
+    public Span span() {
+        return wrapped;
+    }
+}

--- a/src/main/java/io/opentracing/v_030/util/AutoFinishScopeManager.java
+++ b/src/main/java/io/opentracing/v_030/util/AutoFinishScopeManager.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.util;
+
+import io.opentracing.ScopeManager;
+import io.opentracing.Span;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class AutoFinishScopeManager implements ScopeManager {
+    final ThreadLocal<AutoFinishScope> tlsScope = new ThreadLocal<AutoFinishScope>();
+
+    @Override
+    public AutoFinishScope activate(Span span) {
+        return new AutoFinishScope(this, new AtomicInteger(1), span);
+    }
+
+    @Override
+    public AutoFinishScope activate(Span span, boolean finishOnClose) {
+        return new AutoFinishScope(this, new AtomicInteger(1), span);
+    }
+
+    @Override
+    public AutoFinishScope active() {
+        return tlsScope.get();
+    }
+}

--- a/src/test/java/io/opentracing/v_030/shim/ActiveSpanShimTest.java
+++ b/src/test/java/io/opentracing/v_030/shim/ActiveSpanShimTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import org.junit.Before;
+import org.junit.Test;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.mock.MockTracer.Propagator;
+import io.opentracing.v_030.util.AutoFinishScopeManager;
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.v_030.shim.TracerShim;
+import io.opentracing.v_030.tag.Tags;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class ActiveSpanShimTest {
+    private final MockTracer mockTracer = new MockTracer(new AutoFinishScopeManager(),
+            Propagator.TEXT_MAP);
+    private Tracer shim;
+
+    @Before
+    public void before() {
+        mockTracer.reset();
+        shim = new TracerShim(mockTracer);
+    }
+
+    @Test
+    public void log() {
+        shim.buildSpan("one").startActive()
+            .log("myEvent")
+            .close();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+
+        List<MockSpan.LogEntry> logs = finishedSpans.get(0).logEntries();
+        assertEquals(1, logs.size());
+        assertEquals(1, logs.get(0).fields().size());
+        assertEquals("myEvent", logs.get(0).fields().get("event"));
+    }
+
+    @Test
+    public void setBaggageItem() {
+        shim.buildSpan("one").startActive()
+            .setBaggageItem("foobag", "foovalue")
+            .close();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+        assertEquals("foovalue", finishedSpans.get(0).getBaggageItem("foobag"));
+    }
+
+    @Test
+    public void setOperationName() {
+        shim.buildSpan("one").startActive()
+            .setOperationName("1")
+            .close();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+        assertEquals("1", finishedSpans.get(0).operationName());
+    }
+
+    @Test
+    public void setTag() {
+        shim.buildSpan("one").startActive()
+            .setTag("string", "string")
+            .setTag("boolean", true)
+            .setTag("number", 13)
+            .close();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+
+        Map<String, Object> tags = mockTracer.finishedSpans().get(0).tags();
+        assertEquals("string", tags.get("string"));
+        assertEquals(true, tags.get("boolean"));
+        assertEquals(13, tags.get("number"));
+    }
+
+    @Test
+    public void setTagIndirectly() {
+        ActiveSpan span = shim.buildSpan("one").startActive();
+        Tags.COMPONENT.set(span, "shim");
+        span.close();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+
+        Map<String, Object> tags = mockTracer.finishedSpans().get(0).tags();
+        assertEquals("shim", tags.get(Tags.COMPONENT.getKey()));
+    }
+
+}

--- a/src/test/java/io/opentracing/v_030/shim/ActiveSpanShimTest.java
+++ b/src/test/java/io/opentracing/v_030/shim/ActiveSpanShimTest.java
@@ -29,6 +29,8 @@ import io.opentracing.v_030.tag.Tags;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -112,4 +114,14 @@ public class ActiveSpanShimTest {
         assertEquals("shim", tags.get(Tags.COMPONENT.getKey()));
     }
 
+    @Test
+    public void equalsSpan() {
+        io.opentracing.Scope scope = mockTracer.buildSpan("one").startActive();
+        ActiveSpan spanShim = new ActiveSpanShim(scope);
+
+        assertFalse(spanShim.equals(null));
+        assertFalse(spanShim.equals("string"));
+        assertFalse(spanShim.equals(mockTracer.buildSpan("two").startActive()));
+        assertTrue(spanShim.equals(new ActiveSpanShim(scope)));
+    }
 }

--- a/src/test/java/io/opentracing/v_030/shim/AutoFinishTracerShimTest.java
+++ b/src/test/java/io/opentracing/v_030/shim/AutoFinishTracerShimTest.java
@@ -62,7 +62,7 @@ public final class AutoFinishTracerShimTest {
         try {
             span = shim.buildSpan("one").startActive();
             assertNotNull(span);
-            assertNotNull(shim.activeSpan());
+            assertEquals(span, shim.activeSpan());
             assertEquals(0, mockTracer.finishedSpans().size());
         } finally {
             span.deactivate();

--- a/src/test/java/io/opentracing/v_030/shim/AutoFinishTracerShimTest.java
+++ b/src/test/java/io/opentracing/v_030/shim/AutoFinishTracerShimTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import org.junit.Before;
+import org.junit.Test;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.mock.MockTracer.Propagator;
+import io.opentracing.util.ThreadLocalScopeManager;
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.v_030.util.AutoFinishScopeManager;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public final class AutoFinishTracerShimTest {
+    private final MockTracer mockTracer = new MockTracer(new AutoFinishScopeManager(),
+            Propagator.TEXT_MAP);
+    private Tracer shim;
+
+    @Before
+    public void before() {
+        mockTracer.reset();
+        shim = new AutoFinishTracerShim(mockTracer);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void ctorNullTracer() {
+        new AutoFinishTracerShim(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void ctorUnsupportedScopeManager() {
+        MockTracer tracer = new MockTracer(new ThreadLocalScopeManager(),
+                Propagator.TEXT_MAP);
+        new AutoFinishTracerShim(tracer);
+    }
+
+    @Test
+    public void simpleSpan() {
+        ActiveSpan span = null;
+        try {
+            span = shim.buildSpan("one").startActive();
+            assertNotNull(span);
+            assertNotNull(shim.activeSpan());
+            assertEquals(0, mockTracer.finishedSpans().size());
+        } finally {
+            span.deactivate();
+        }
+
+        assertNull(shim.activeSpan());
+        assertEquals(1, mockTracer.finishedSpans().size());
+    }
+
+    @Test
+    public void captureSpan() {
+        int captureCount = 3;
+        ActiveSpan.Continuation continuations[] = new ActiveSpan.Continuation[captureCount];
+
+        ActiveSpan span = null;
+        try {
+            span = shim.buildSpan("one").startActive();
+            assertNotNull(shim.activeSpan());
+            assertEquals(0, mockTracer.finishedSpans().size());
+
+            for (int i = 0; i < captureCount; i++) {
+                ActiveSpan.Continuation cont = span.capture();
+                continuations[i] = cont;
+                assertNotNull(cont);
+            }
+        } finally {
+            span.deactivate();
+        }
+
+        for (int i = 0; i < captureCount; i++) {
+            assertNull(shim.activeSpan());
+            assertEquals(0, mockTracer.finishedSpans().size());
+
+            try {
+                continuations[i].activate();
+                assertNotNull(shim.activeSpan());
+                shim.activeSpan().setTag(Integer.toString(i), "value");
+
+            } finally {
+                shim.activeSpan().deactivate();
+            }
+        }
+
+        assertNull(shim.activeSpan());
+        assertEquals(1, mockTracer.finishedSpans().size());
+
+        Map<String, Object> tags = mockTracer.finishedSpans().get(0).tags();
+        assertEquals(captureCount, tags.size());
+    }
+}

--- a/src/test/java/io/opentracing/v_030/shim/SpanShimTest.java
+++ b/src/test/java/io/opentracing/v_030/shim/SpanShimTest.java
@@ -28,6 +28,8 @@ import io.opentracing.v_030.tag.Tags;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -119,5 +121,16 @@ public class SpanShimTest {
 
         Map<String, Object> tags = mockTracer.finishedSpans().get(0).tags();
         assertEquals("shim", tags.get(Tags.COMPONENT.getKey()));
+    }
+
+    @Test
+    public void equalsSpan() {
+        io.opentracing.Span span = mockTracer.buildSpan("one").start();
+        Span spanShim = new SpanShim(span);
+
+        assertFalse(spanShim.equals(null));
+        assertFalse(spanShim.equals("string"));
+        assertFalse(spanShim.equals(mockTracer.buildSpan("two").start()));
+        assertTrue(spanShim.equals(new SpanShim(span)));
     }
 }

--- a/src/test/java/io/opentracing/v_030/shim/SpanShimTest.java
+++ b/src/test/java/io/opentracing/v_030/shim/SpanShimTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import org.junit.Before;
+import org.junit.Test;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.mock.MockTracer.Propagator;
+import io.opentracing.v_030.util.AutoFinishScopeManager;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.v_030.shim.TracerShim;
+import io.opentracing.v_030.tag.Tags;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class SpanShimTest {
+    private final MockTracer mockTracer = new MockTracer(new AutoFinishScopeManager(),
+            Propagator.TEXT_MAP);
+    private Tracer shim;
+
+    @Before
+    public void before() {
+        mockTracer.reset();
+        shim = new TracerShim(mockTracer);
+    }
+
+    @Test
+    public void finishMicros() {
+        shim.buildSpan("one").startManual()
+            .finish(10100);
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+        assertEquals(10100, finishedSpans.get(0).finishMicros());
+    }
+
+    @Test
+    public void log() {
+        shim.buildSpan("one").startManual()
+            .log("myEvent")
+            .finish();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+
+        List<MockSpan.LogEntry> logs = finishedSpans.get(0).logEntries();
+        assertEquals(1, logs.size());
+        assertEquals(1, logs.get(0).fields().size());
+        assertEquals("myEvent", logs.get(0).fields().get("event"));
+    }
+
+    @Test
+    public void setBaggageItem() {
+        shim.buildSpan("one").startManual()
+            .setBaggageItem("foobag", "foovalue")
+            .finish();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+        assertEquals("foovalue", finishedSpans.get(0).getBaggageItem("foobag"));
+    }
+
+    @Test
+    public void setOperationName() {
+        shim.buildSpan("one").startManual()
+            .setOperationName("1")
+            .finish();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+        assertEquals("1", finishedSpans.get(0).operationName());
+    }
+
+    @Test
+    public void setTag() {
+        shim.buildSpan("one").startManual()
+            .setTag("string", "string")
+            .setTag("boolean", true)
+            .setTag("number", 13)
+            .finish();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+
+        Map<String, Object> tags = mockTracer.finishedSpans().get(0).tags();
+        assertEquals("string", tags.get("string"));
+        assertEquals(true, tags.get("boolean"));
+        assertEquals(13, tags.get("number"));
+    }
+
+    @Test
+    public void setTagIndirectly() {
+        Span span = shim.buildSpan("one").startManual();
+        Tags.COMPONENT.set(span, "shim");
+        span.finish();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(1, finishedSpans.size());
+
+        Map<String, Object> tags = mockTracer.finishedSpans().get(0).tags();
+        assertEquals("shim", tags.get(Tags.COMPONENT.getKey()));
+    }
+}

--- a/src/test/java/io/opentracing/v_030/shim/TracerShimTest.java
+++ b/src/test/java/io/opentracing/v_030/shim/TracerShimTest.java
@@ -65,7 +65,7 @@ public final class TracerShimTest {
         try {
             span = shim.buildSpan("one").startActive();
             assertNotNull(span);
-            assertNotNull(shim.activeSpan());
+            assertEquals(span, shim.activeSpan());
             assertEquals(0, mockTracer.finishedSpans().size());
         } finally {
             span.deactivate();
@@ -109,7 +109,7 @@ public final class TracerShimTest {
         try {
             active = shim.makeActive(span);
             assertNotNull(active);
-            assertNotNull(shim.activeSpan());
+            assertEquals(active, shim.activeSpan());
             assertEquals(0, mockTracer.finishedSpans().size());
         } finally {
             active.deactivate();

--- a/src/test/java/io/opentracing/v_030/shim/TracerShimTest.java
+++ b/src/test/java/io/opentracing/v_030/shim/TracerShimTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.shim;
+
+import org.junit.Before;
+import org.junit.Test;
+import io.opentracing.Scope;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.mock.MockTracer.Propagator;
+import io.opentracing.util.ThreadLocalScopeManager;
+import io.opentracing.v_030.ActiveSpan;
+import io.opentracing.v_030.References;
+import io.opentracing.v_030.Span;
+import io.opentracing.v_030.SpanContext;
+import io.opentracing.v_030.Tracer;
+import io.opentracing.v_030.propagation.Format;
+import io.opentracing.v_030.propagation.TextMapExtractAdapter;
+import io.opentracing.v_030.propagation.TextMapInjectAdapter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public final class TracerShimTest {
+    private final MockTracer mockTracer = new MockTracer(new ThreadLocalScopeManager(),
+            Propagator.TEXT_MAP);
+    private Tracer shim;
+
+    @Before
+    public void before() {
+        mockTracer.reset();
+        shim = new TracerShim(mockTracer);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void ctorNullTracer() {
+        new TracerShim(null);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void spanCapture() {
+        shim.buildSpan("one").startActive().capture();
+    }
+
+    @Test
+    public void activeSpan() {
+        ActiveSpan span = null;
+        try {
+            span = shim.buildSpan("one").startActive();
+            assertNotNull(span);
+            assertNotNull(shim.activeSpan());
+            assertEquals(0, mockTracer.finishedSpans().size());
+        } finally {
+            span.deactivate();
+        }
+
+        assertNull(shim.activeSpan());
+        assertEquals(1, mockTracer.finishedSpans().size());
+        assertEquals("one", mockTracer.finishedSpans().get(0).operationName());
+    }
+
+    @Test
+    public void activeSpanOnTheSide() {
+        Scope scope = null;
+        try {
+            scope = mockTracer.buildSpan("one").startActive();
+            assertNotNull(shim.activeSpan());
+        } finally {
+            scope.close();
+        }
+
+        assertNull(shim.activeSpan());
+    }
+
+    @Test
+    public void activeSpanNone() {
+        assertNull(shim.activeSpan());
+
+        Span span = shim.buildSpan("one").startManual();
+        assertNull(shim.activeSpan());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void makeActiveNull() {
+        shim.makeActive(null);
+    }
+
+    @Test
+    public void makeActive() {
+        Span span = shim.buildSpan("one").startManual();
+        ActiveSpan active = null;
+        try {
+            active = shim.makeActive(span);
+            assertNotNull(active);
+            assertNotNull(shim.activeSpan());
+            assertEquals(0, mockTracer.finishedSpans().size());
+        } finally {
+            active.deactivate();
+        }
+
+        assertNull(shim.activeSpan());
+        assertEquals(1, mockTracer.finishedSpans().size());
+    }
+
+    @Test
+    public void injectExtractTextMap() {
+        Map<String, String> injectMap = new HashMap<String, String>();
+
+        Span span = shim.buildSpan("parent").startManual();
+        span.finish();
+        shim.inject(span.context(), Format.Builtin.TEXT_MAP, new TextMapInjectAdapter(injectMap));
+
+        SpanContext extract = shim.extract(Format.Builtin.TEXT_MAP, new TextMapExtractAdapter(injectMap));
+        shim.buildSpan("child").asChildOf(extract).startManual().finish();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(2, finishedSpans.size());
+        assertEquals(finishedSpans.get(0).context().traceId(), finishedSpans.get(1).context().traceId());
+    }
+
+    @Test
+    public void injectExtractHttp() {
+        Map<String, String> injectMap = new HashMap<String, String>();
+
+        Span span = shim.buildSpan("parent").startManual();
+        span.finish();
+        shim.inject(span.context(), Format.Builtin.HTTP_HEADERS, new TextMapInjectAdapter(injectMap));
+
+        SpanContext extract = shim.extract(Format.Builtin.HTTP_HEADERS, new TextMapExtractAdapter(injectMap));
+        shim.buildSpan("child").asChildOf(extract).startManual().finish();
+
+        List<MockSpan> finishedSpans = mockTracer.finishedSpans();
+        assertEquals(2, finishedSpans.size());
+        assertEquals(finishedSpans.get(0).context().traceId(), finishedSpans.get(1).context().traceId());
+    }
+
+    @Test
+    public void builderAsChildOfSpan() {
+        Span parentSpan = shim.buildSpan("parent").startManual();
+        Span childSpan = shim.buildSpan("child").asChildOf(parentSpan).startManual();
+        childSpan.finish();
+        parentSpan.finish();
+
+        List<MockSpan> spans = mockTracer.finishedSpans();
+        assertEquals(2, spans.size());
+        assertEquals("child", spans.get(0).operationName());
+        assertEquals("parent", spans.get(1).operationName());
+        assertEquals(spans.get(0).parentId(), spans.get(1).context().spanId());
+    }
+
+    @Test
+    public void builderAsChildOfActiveSpan() {
+        ActiveSpan parentSpan, childSpan, childSpan2;
+        parentSpan = childSpan = childSpan2 = null;
+        try {
+            parentSpan = shim.buildSpan("parent").startActive();
+            try {
+                childSpan = shim.buildSpan("child").startActive();
+                try {
+                    childSpan2 = shim.buildSpan("child2").asChildOf(parentSpan).startActive();
+                } finally {
+                    childSpan2.deactivate();
+                }
+            } finally {
+                childSpan.deactivate();
+            }
+        } finally {
+            parentSpan.deactivate();
+        }
+
+        List<MockSpan> spans = mockTracer.finishedSpans();
+        assertEquals(3, spans.size());
+        assertEquals("child2", spans.get(0).operationName());
+        assertEquals("child", spans.get(1).operationName());
+        assertEquals("parent", spans.get(2).operationName());
+        assertEquals(spans.get(0).parentId(), spans.get(2).context().spanId());
+    }
+
+    @Test
+    public void builderAsChildOfContext() {
+        Span parentSpan = shim.buildSpan("parent").startManual();
+        Span childSpan = shim.buildSpan("child").asChildOf(parentSpan.context()).startManual();
+        childSpan.finish();
+        parentSpan.finish();
+
+        List<MockSpan> spans = mockTracer.finishedSpans();
+        assertEquals(2, spans.size());
+        assertEquals("child", spans.get(0).operationName());
+        assertEquals("parent", spans.get(1).operationName());
+        assertEquals(spans.get(0).parentId(), spans.get(1).context().spanId());
+    }
+
+    @Test
+    public void builderIgnoreActiveSpan() {
+        ActiveSpan parentSpan, childSpan;
+        parentSpan = childSpan = null;
+        try {
+            parentSpan = shim.buildSpan("one").startActive();
+            try {
+                childSpan = shim.buildSpan("two").ignoreActiveSpan().startActive();
+            } finally {
+                childSpan.deactivate();
+            }
+        } finally {
+            parentSpan.deactivate();
+        }
+
+        List<MockSpan> spans = mockTracer.finishedSpans();
+        assertEquals(2, spans.size());
+        assertEquals("two", spans.get(0).operationName());
+        assertEquals("one", spans.get(1).operationName());
+        assertNotEquals(spans.get(0).context().traceId(), spans.get(1).context().traceId());
+    }
+
+    @Test
+    public void builderAddReference() {
+        Span parentSpan = shim.buildSpan("parent").startManual();
+        Span childSpan = shim.buildSpan("child").addReference(References.CHILD_OF, parentSpan.context()).startManual();
+        childSpan.finish();
+        parentSpan.finish();
+
+        List<MockSpan> spans = mockTracer.finishedSpans();
+        assertEquals(2, spans.size());
+        assertEquals("child", spans.get(0).operationName());
+        assertEquals("parent", spans.get(1).operationName());
+        assertEquals(spans.get(0).parentId(), spans.get(1).context().spanId());
+    }
+
+    @Test
+    public void builderWithTag() {
+        shim.buildSpan("one")
+            .withTag("string", "string")
+            .withTag("boolean", true)
+            .withTag("number", 13)
+            .startManual()
+            .finish();
+
+        assertEquals(1, mockTracer.finishedSpans().size());
+        
+        Map<String, Object> tags = mockTracer.finishedSpans().get(0).tags();
+        assertEquals("string", tags.get("string"));
+        assertEquals(true, tags.get("boolean"));
+        assertEquals(13, tags.get("number"));
+    }
+
+    @Test
+    public void builderWithStartTimestamp() {
+        shim.buildSpan("one")
+            .withStartTimestamp(113)
+            .startManual()
+            .finish();
+
+        assertEquals(1, mockTracer.finishedSpans().size());
+        assertEquals(113, mockTracer.finishedSpans().get(0).startMicros());
+    }
+
+    @Test
+    public void builderStart() {
+        shim.buildSpan("one").start().finish();
+
+        assertEquals(1, mockTracer.finishedSpans().size());
+        assertEquals("one", mockTracer.finishedSpans().get(0).operationName());
+    }
+}

--- a/src/test/java/io/opentracing/v_030/util/AutoFinishScopeManagerTest.java
+++ b/src/test/java/io/opentracing/v_030/util/AutoFinishScopeManagerTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.util;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class AutoFinishScopeManagerTest {
+    private AutoFinishScopeManager source;
+    @Before
+    public void before() throws Exception {
+        source = new AutoFinishScopeManager();
+    }
+
+    @Test
+    public void missingScope() throws Exception {
+        Scope missingSpan = source.active();
+        assertNull(missingSpan);
+    }
+
+    @Test
+    public void activateSpan() throws Exception {
+        Span span = mock(Span.class);
+
+        // We can't use 1.7 features like try-with-resources in this repo without meddling with pom details for tests.
+        Scope active = source.activate(span);
+        try {
+            assertNotNull(active);
+            Scope otherScope = source.active();
+            assertEquals(otherScope, active);
+        } finally {
+            active.close();
+        }
+
+        // Make sure the Span got finish()ed.
+        verify(span).finish();
+
+        // And now it's gone:
+        Scope missingSpan = source.active();
+        assertNull(missingSpan);
+    }
+
+}

--- a/src/test/java/io/opentracing/v_030/util/AutoFinishScopeTest.java
+++ b/src/test/java/io/opentracing/v_030/util/AutoFinishScopeTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2016-2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.v_030.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AutoFinishScopeTest {
+    private AutoFinishScopeManager manager;
+
+    @Before
+    public void before() throws Exception {
+        manager = new AutoFinishScopeManager();
+    }
+
+    @Test
+    public void continuation() throws Exception {
+        Span span = mock(Span.class);
+
+        // Quasi try-with-resources (this is 1.6).
+        AutoFinishScope active = (AutoFinishScope)manager.activate(span);
+        AutoFinishScope.Continuation continued = null;
+        try {
+            assertNotNull(active);
+            continued = active.capture();
+        } finally {
+            active.close();
+        }
+
+        // Make sure the Span was not finished since there was a capture().
+        verify(span, never()).finish();
+
+        // Activate the continuation.
+        try {
+            active = continued.activate();
+        } finally {
+            active.close();
+        }
+
+        // Now the Span should be finished.
+        verify(span, times(1)).finish();
+
+        // And now it's no longer active.
+        Scope missingSpan = manager.active();
+        assertNull(missingSpan);
+    }
+
+    @Test
+    public void implicitSpanStack() throws Exception {
+        Span backgroundSpan = mock(Span.class);
+        Span foregroundSpan = mock(Span.class);
+
+        // Quasi try-with-resources (this is 1.6).
+        Scope backgroundActive = manager.activate(backgroundSpan);
+        try {
+            assertNotNull(backgroundActive);
+
+            // Activate a new Scope on top of the background one.
+            Scope foregroundActive = manager.activate(foregroundSpan);
+            try {
+                Scope shouldBeForeground = manager.active();
+                assertEquals(foregroundActive, shouldBeForeground);
+            } finally {
+                foregroundActive.close();
+            }
+
+            // And now the backgroundActive should be reinstated.
+            Scope shouldBeBackground = manager.active();
+            assertEquals(backgroundActive, shouldBeBackground);
+        } finally {
+            backgroundActive.close();
+        }
+
+        // The background and foreground Spans should be finished.
+        verify(backgroundSpan, times(1)).finish();
+        verify(foregroundSpan, times(1)).finish();
+
+        // And now nothing is active.
+        Scope missingSpan = manager.active();
+        assertNull(missingSpan);
+    }
+
+    @Test
+    public void testDeactivateWhenDifferentSpanIsActive() {
+        Span span = mock(Span.class);
+
+        Scope active = manager.activate(span);
+        manager.activate(mock(Span.class));
+        active.close();
+
+        verify(span, times(0)).finish();
+    }
+}


### PR DESCRIPTION
This is an updated PR for putting the Shim layer in a separated repo (originated from opentracing/opentracing-java#221, and tuned as per Yuri's suggestion to only ask for a review of the very Shim layer).

Notes on it overall:

* Provides a default TracerShim which wraps a 0.31 Tracer with its ScopeManager, providing no Continuation support out of the box.

* Provides also a AutoFinishTracerShim which wraps a 0.31 Tracer using the contained AutoFinishScopeManager, which keeps the thread-local, reference-count based logic to support Continuations.

* It still throws IllegalArgumentException on null values of some methods (i.e. SpanBuilder.childOf() - throwing this would prevent a NullReferenceException when casting the wrapped object. Pavol mention we should not throw such Exception - so, what should we throw there instead? Or how should we report such errors? The spec doesn't mention thrown exceptions...

* Currently it's a minimalistic approach, and wondering if we this is good enough for `Tracer` authors who were using their own span propagation and/or using their own Span lifetime handling.

No Travis/CentralSync support yet (will do after we get this properly merged).