### PR TITLE
Do not try to create wrappers for null format/carriers.

### DIFF
--- a/src/main/java/io/opentracing/v_030/shim/FormatConverter.java
+++ b/src/main/java/io/opentracing/v_030/shim/FormatConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 The OpenTracing Authors
+ * Copyright 2016-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -44,6 +44,10 @@ final class FormatConverter {
     }
 
     public static <C> Object toUpstreamExtractCarrier(Format format, C carrier) {
+        if (carrier == null) {
+            return null;
+        }
+
         if (format == Format.Builtin.TEXT_MAP || format == Format.Builtin.HTTP_HEADERS) {
             return new TextMapUpstreamShim((TextMap)carrier);
         }
@@ -56,6 +60,10 @@ final class FormatConverter {
     }
 
     public static <C> Object toUpstreamInjectCarrier(Format format, C carrier) {
+        if (carrier == null) {
+            return null;
+        }
+
         if (format == Format.Builtin.TEXT_MAP || format == Format.Builtin.HTTP_HEADERS) {
             return new TextMapUpstreamShim((TextMap)carrier);
         }

--- a/src/main/java/io/opentracing/v_030/shim/TracerShim.java
+++ b/src/main/java/io/opentracing/v_030/shim/TracerShim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 The OpenTracing Authors
+ * Copyright 2016-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/test/java/io/opentracing/v_030/shim/TracerShimTest.java
+++ b/src/test/java/io/opentracing/v_030/shim/TracerShimTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 The OpenTracing Authors
+ * Copyright 2016-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -195,6 +195,51 @@ public final class TracerShimTest {
             excThrown = true;
         }
 
+        assertTrue(excThrown);
+    }
+
+    @Test
+    public void injectExtractNullFormat() {
+        Span span = shim.buildSpan("parent").startManual();
+        span.finish();
+
+        Map<String, String> map = new HashMap<String, String>();
+        boolean excThrown = false;
+        try {
+            shim.inject(span.context(), null, new TextMapInjectAdapter(map));
+        } catch (IllegalArgumentException e) {
+            excThrown = true;
+        }
+        assertTrue(excThrown);
+
+        excThrown = false;
+        try {
+            shim.extract(null, new TextMapExtractAdapter(map));
+        } catch (IllegalArgumentException e) {
+            excThrown = true;
+        }
+        assertTrue(excThrown);
+    }
+
+    @Test
+    public void injectExtractNullCarrier() {
+        Span span = shim.buildSpan("parent").startManual();
+        span.finish();
+
+        boolean excThrown = false;
+        try {
+            shim.inject(span.context(), Format.Builtin.HTTP_HEADERS, null);
+        } catch (IllegalArgumentException e) {
+            excThrown = true;
+        }
+        assertTrue(excThrown);
+
+        excThrown = false;
+        try {
+            shim.extract(Format.Builtin.HTTP_HEADERS, null);
+        } catch (IllegalArgumentException e) {
+            excThrown = true;
+        }
         assertTrue(excThrown);
     }
 


### PR DESCRIPTION
When null format/carrier values are passed to Tracer's inject()
or extract(), return the value immediately without building
a wrapper, and let the underneath Tracer handle that. This will
prevent getting a not-obvious NullReferenceException.