### PR TITLE
Prevent Span/ActiveSpan shims to be used directly.

### DIFF
--- a/src/main/java/io/opentracing/v_030/shim/ActiveSpanShim.java
+++ b/src/main/java/io/opentracing/v_030/shim/ActiveSpanShim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 The OpenTracing Authors
+ * Copyright 2016-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -23,7 +23,7 @@ public class ActiveSpanShim implements ActiveSpan, SpanWrapper {
     final Scope scope;
     final SpanContext context;
 
-    public ActiveSpanShim(Scope scope) {
+    protected ActiveSpanShim(Scope scope) {
         if (scope == null) {
             throw new IllegalArgumentException("scope");
         }

--- a/src/main/java/io/opentracing/v_030/shim/SpanShim.java
+++ b/src/main/java/io/opentracing/v_030/shim/SpanShim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 The OpenTracing Authors
+ * Copyright 2016-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -22,7 +22,7 @@ public class SpanShim implements Span, SpanWrapper {
     final io.opentracing.Span span;
     final SpanContext context;
 
-    public SpanShim(io.opentracing.Span span) {
+    protected SpanShim(io.opentracing.Span span) {
         this.span = span;
         this.context = new SpanContextShim(span().context());
     }

--- a/src/main/java/io/opentracing/v_030/shim/TracerShim.java
+++ b/src/main/java/io/opentracing/v_030/shim/TracerShim.java
@@ -40,11 +40,11 @@ public class TracerShim implements Tracer {
     }
 
     protected ActiveSpanShim createActiveSpanShim(Scope scope) {
-        return new ActiveSpanShim(scope);
+        return new SimpleActiveSpanShim(scope);
     }
 
     protected SpanShim createSpanShim(io.opentracing.Span span) {
-        return new SpanShim(span);
+        return new SimpleSpanShim(span);
     }
 
     @Override
@@ -83,6 +83,18 @@ public class TracerShim implements Tracer {
         io.opentracing.SpanContext context = tracer.extract(FormatConverter.toUpstreamFormat(format),
                 FormatConverter.toUpstreamExtractCarrier(format, carrier));
         return new SpanContextShim(context);
+    }
+
+    private final static class SimpleActiveSpanShim extends ActiveSpanShim {
+        public SimpleActiveSpanShim(io.opentracing.Scope scope) {
+            super(scope);
+        }
+    }
+
+    private final static class SimpleSpanShim extends SpanShim {
+        public SimpleSpanShim(io.opentracing.Span span) {
+            super(span);
+        }
     }
 
     private final class SpanBuilderShim implements Tracer.SpanBuilder {


### PR DESCRIPTION
ActiveSpan/Span should be used along some specific
ThreadShim implementation. This is specially
import for non-simple shims, such as AutoFinishTracerShim
or developers extending our shim layer overall.